### PR TITLE
change reinit in wandb.init() to allow for multiple runs

### DIFF
--- a/rlgym_learn_algos/logging/wandb_metrics_logger.py
+++ b/rlgym_learn_algos/logging/wandb_metrics_logger.py
@@ -140,7 +140,7 @@ class WandbMetricsLogger(
             name=run_name,
             id=self.run_id,
             resume="allow",
-            reinit="finish_previous",
+            reinit="create_new",
             settings=wandb.Settings(
                 **self.config.metrics_logger_config.settings_kwargs
             ),


### PR DESCRIPTION
…string, which is the equivalent, to get rid of deprecation warning

This should be no change in functionality, just getting rid of the deprecation warning.