### PR TITLE
Bug: Wandb doesn't load nor validate the config of its inner metrics logger

### DIFF
--- a/rlgym_learn_algos/logging/wandb_metrics_logger.py
+++ b/rlgym_learn_algos/logging/wandb_metrics_logger.py
@@ -38,6 +38,7 @@ class WandbMetricsLoggerConfigModel(BaseModel, extra="forbid"):
     new_run_with_timestamp_suffix: bool = False
     additional_wandb_run_config: Dict[str, Any] = Field(default_factory=dict)
     settings_kwargs: Dict[str, Any] = Field(default_factory=dict)
+    inner_metrics_logger_config: InnerMetricsLoggerConfig | None = None
 
 
 @dataclass
@@ -46,10 +47,7 @@ class WandbAdditionalDerivedConfig(
 ):
     derived_wandb_run_config: Dict[str, Any] = Field(default_factory=dict)
     timestamp_suffix: Optional[str] = None
-    inner_metrics_logger_config: InnerMetricsLoggerConfig = None
-    inner_metrics_logger_additional_derived_config: (
-        InnerMetricsLoggerAdditionalDerivedConfig
-    ) = None
+    inner_metrics_logger_additional_derived_config: InnerMetricsLoggerAdditionalDerivedConfig = None
 
 
 class WandbMetricsLogger(
@@ -90,7 +88,12 @@ class WandbMetricsLogger(
         self.inner_metrics_logger.report_metrics()
 
     def validate_config(self, config_obj: Any):
-        return WandbMetricsLoggerConfigModel.model_validate(config_obj)
+        _config = WandbMetricsLoggerConfigModel.model_validate(config_obj)
+
+        _config.inner_metrics_logger_config = self.inner_metrics_logger.validate_config(
+            config_obj["inner_metrics_logger_config"]
+        )
+        return _config
 
     def load(self, config):
         self.config = config
@@ -98,7 +101,7 @@ class WandbMetricsLogger(
             DerivedMetricsLoggerConfig(
                 checkpoint_load_folder=config.checkpoint_load_folder,
                 agent_controller_name=config.agent_controller_name,
-                metrics_logger_config=config.additional_derived_config.inner_metrics_logger_config,
+                metrics_logger_config=config.metrics_logger_config.inner_metrics_logger_config,
                 additional_derived_config=config.additional_derived_config.inner_metrics_logger_additional_derived_config,
             )
         )

--- a/rlgym_learn_algos/logging/wandb_metrics_logger.py
+++ b/rlgym_learn_algos/logging/wandb_metrics_logger.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import Any, Dict, Generic, List, Optional, TypeVar
 
 import wandb
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from rlgym_learn.api import AgentControllerData
 
 from .dict_metrics_logger import DictMetricsLogger
@@ -29,7 +29,9 @@ def convert_nested_dict(d):
     return new
 
 
-class WandbMetricsLoggerConfigModel(BaseModel, extra="forbid"):
+class WandbMetricsLoggerConfigModel(BaseModel, Generic[InnerMetricsLoggerConfig]):
+    model_config = ConfigDict(extra="forbid")
+
     enable: bool = True
     project: str = "rlgym-learn"
     group: str = "unnamed-runs"
@@ -38,13 +40,11 @@ class WandbMetricsLoggerConfigModel(BaseModel, extra="forbid"):
     new_run_with_timestamp_suffix: bool = False
     additional_wandb_run_config: Dict[str, Any] = Field(default_factory=dict)
     settings_kwargs: Dict[str, Any] = Field(default_factory=dict)
-    inner_metrics_logger_config: InnerMetricsLoggerConfig | None = None
+    inner_metrics_logger_config: Optional[InnerMetricsLoggerConfig] = None
 
 
 @dataclass
-class WandbAdditionalDerivedConfig(
-    Generic[InnerMetricsLoggerConfig, InnerMetricsLoggerAdditionalDerivedConfig]
-):
+class WandbAdditionalDerivedConfig(Generic[InnerMetricsLoggerAdditionalDerivedConfig]):
     derived_wandb_run_config: Dict[str, Any] = Field(default_factory=dict)
     timestamp_suffix: Optional[str] = None
     inner_metrics_logger_additional_derived_config: InnerMetricsLoggerAdditionalDerivedConfig = None
@@ -52,10 +52,8 @@ class WandbAdditionalDerivedConfig(
 
 class WandbMetricsLogger(
     MetricsLogger[
-        WandbMetricsLoggerConfigModel,
-        WandbAdditionalDerivedConfig[
-            InnerMetricsLoggerConfig, InnerMetricsLoggerAdditionalDerivedConfig
-        ],
+        WandbMetricsLoggerConfigModel[InnerMetricsLoggerConfig],
+        WandbAdditionalDerivedConfig[InnerMetricsLoggerAdditionalDerivedConfig],
         AgentControllerData,
     ],
     Generic[


### PR DESCRIPTION
The Wandb metrics logger doesn't allow its inner metrics logger to have any config by ignoring the inner config model validation and only calling its own model validation. The inner metrics logger should be able to validate its own config because it's the only one that knows what it expects.

Below is an example using a simple metrics logger that requires model validation and loading to be able to collect data

Before fix:
<img width="1278" height="117" alt="image" src="https://github.com/user-attachments/assets/c8d84338-2a6f-4874-b86f-986c9e815c72" />

After fix:
<img width="1076" height="147" alt="image" src="https://github.com/user-attachments/assets/74d6aa5e-4911-49bd-ab08-9d3257807523" />

