### PR TITLE
fix: Check torch.device instead of torch.dtype

### DIFF
--- a/rlgym_learn_algos/util/torch_pydantic.py
+++ b/rlgym_learn_algos/util/torch_pydantic.py
@@ -103,7 +103,7 @@ class _TorchDevicePydanticAnnotation:
             python_schema=core_schema.union_schema(
                 [
                     # check if it's an instance first before doing any further work
-                    core_schema.is_instance_schema(torch.dtype),
+                    core_schema.is_instance_schema(torch.device),
                     from_str_schema,
                     from_int_schema,
                 ]


### PR DESCRIPTION
Test script:
```python
class MyConfig(BaseModel):
    dtype: PydanticTorchDtype
    device: PydanticTorchDevice


if __name__ == "__main__":
    print(MyConfig(dtype="float32", device=torch.float32))
```

Before the fix, this was considered as valid, despite the device being a torch dtype.